### PR TITLE
Add FXMacroData MCP configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,12 +180,15 @@ cp env.example .env
 # 编辑 mcp_config.json 文件，配置MCP服务器
 ```
 
-示例配置已包含 FXMacroData 远程 MCP 服务器：
+示例配置包含一个默认禁用的 FXMacroData 远程 MCP 服务器。需要宏观数据时，
+将 `disabled` 改为 `false`；服务端会通过 MCP 工具发现提供可用能力，项目本身
+不复制或维护 FXMacroData 的工具模式。
 
 ```json
 {
-  "servers": {
+  "mcpServers": {
     "fxmacrodata": {
+      "disabled": true,
       "transport": "streamable_http",
       "url": "https://mcp.fxmacrodata.com",
       "timeout": 600
@@ -194,8 +197,9 @@ cp env.example .env
 }
 ```
 
-启用相关智能体的 MCP 权限后，可使用宏观日历、指标、FX、COT、商品、
-市场时段和央行新闻工具来补充交易分析。
+启用该服务器和相关智能体的 MCP 权限后，可使用服务端公开的宏观日历、
+指标、FX、COT、商品、市场时段和央行新闻工具来补充交易分析。该远程
+服务器不需要把 FXMacroData API 密钥写入本仓库的配置文件。
 
 ### 🌐 Web前端使用
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,23 @@ cp env.example .env
 # 编辑 mcp_config.json 文件，配置MCP服务器
 ```
 
+示例配置已包含 FXMacroData 远程 MCP 服务器：
+
+```json
+{
+  "servers": {
+    "fxmacrodata": {
+      "transport": "streamable_http",
+      "url": "https://mcp.fxmacrodata.com",
+      "timeout": 600
+    }
+  }
+}
+```
+
+启用相关智能体的 MCP 权限后，可使用宏观日历、指标、FX、COT、商品、
+市场时段和央行新闻工具来补充交易分析。
+
 ### 🌐 Web前端使用
 
 **推荐使用方式** - 通过Web界面进行交互：

--- a/mcp_config.json
+++ b/mcp_config.json
@@ -1,21 +1,4 @@
 {
-  "servers": {
-    "finance-mcp": {
-      "disabled": false,
-      "timeout": 600,
-      "transport": "streamable_http",
-      "url": "https://finvestai.top/mcp",
-      "headers": {
-        "X-Tushare-Token": "您的tushare令牌"
-      }
-    },
-    "fxmacrodata": {
-      "disabled": false,
-      "timeout": 600,
-      "transport": "streamable_http",
-      "url": "https://mcp.fxmacrodata.com"
-    }
-  },
   "mcpServers": {
     "finance-mcp": {
       "disabled": false,
@@ -27,7 +10,7 @@
       }
     },
     "fxmacrodata": {
-      "disabled": false,
+      "disabled": true,
       "timeout": 600,
       "transport": "streamable_http",
       "url": "https://mcp.fxmacrodata.com"

--- a/mcp_config.json
+++ b/mcp_config.json
@@ -1,4 +1,21 @@
 {
+  "servers": {
+    "finance-mcp": {
+      "disabled": false,
+      "timeout": 600,
+      "transport": "streamable_http",
+      "url": "https://finvestai.top/mcp",
+      "headers": {
+        "X-Tushare-Token": "您的tushare令牌"
+      }
+    },
+    "fxmacrodata": {
+      "disabled": false,
+      "timeout": 600,
+      "transport": "streamable_http",
+      "url": "https://mcp.fxmacrodata.com"
+    }
+  },
   "mcpServers": {
     "finance-mcp": {
       "disabled": false,
@@ -8,6 +25,12 @@
       "headers": {
         "X-Tushare-Token": "您的tushare令牌"
       }
+    },
+    "fxmacrodata": {
+      "disabled": false,
+      "timeout": 600,
+      "transport": "streamable_http",
+      "url": "https://mcp.fxmacrodata.com"
     }
   }
 }

--- a/mcp_config.json.example
+++ b/mcp_config.json.example
@@ -1,21 +1,4 @@
 {
-  "servers": {
-    "finance-mcp": {
-      "disabled": false,
-      "timeout": 600,
-      "transport": "streamable_http",
-      "url": "https://finvestai.top/mcp",
-      "headers": {
-        "X-Tushare-Token": "您的tushare令牌"
-      }
-    },
-    "fxmacrodata": {
-      "disabled": false,
-      "timeout": 600,
-      "transport": "streamable_http",
-      "url": "https://mcp.fxmacrodata.com"
-    }
-  },
   "mcpServers": {
     "finance-mcp": {
       "disabled": false,
@@ -27,7 +10,7 @@
       }
     },
     "fxmacrodata": {
-      "disabled": false,
+      "disabled": true,
       "timeout": 600,
       "transport": "streamable_http",
       "url": "https://mcp.fxmacrodata.com"

--- a/mcp_config.json.example
+++ b/mcp_config.json.example
@@ -1,4 +1,21 @@
 {
+  "servers": {
+    "finance-mcp": {
+      "disabled": false,
+      "timeout": 600,
+      "transport": "streamable_http",
+      "url": "https://finvestai.top/mcp",
+      "headers": {
+        "X-Tushare-Token": "您的tushare令牌"
+      }
+    },
+    "fxmacrodata": {
+      "disabled": false,
+      "timeout": 600,
+      "transport": "streamable_http",
+      "url": "https://mcp.fxmacrodata.com"
+    }
+  },
   "mcpServers": {
     "finance-mcp": {
       "disabled": false,
@@ -8,6 +25,12 @@
       "headers": {
         "X-Tushare-Token": "您的tushare令牌"
       }
+    },
+    "fxmacrodata": {
+      "disabled": false,
+      "timeout": 600,
+      "transport": "streamable_http",
+      "url": "https://mcp.fxmacrodata.com"
     }
   }
 }

--- a/src/mcp_config.py
+++ b/src/mcp_config.py
@@ -1,0 +1,29 @@
+"""Helpers for normalizing the repository's MCP server configuration."""
+
+from typing import Any, Dict, Mapping
+
+
+def configured_servers(config: Mapping[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """Return the configured server map, accepting the legacy key as fallback."""
+    servers = config.get("mcpServers")
+    if servers is None:
+        servers = config.get("servers", {})
+    if not isinstance(servers, Mapping):
+        return {}
+    return {
+        str(name): dict(server)
+        for name, server in servers.items()
+        if isinstance(server, Mapping)
+    }
+
+
+def active_servers(servers: Mapping[str, Mapping[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    """Remove disabled servers and fields not accepted by the MCP client."""
+    active: Dict[str, Dict[str, Any]] = {}
+    for name, server in servers.items():
+        if server.get("disabled", False):
+            continue
+        active[str(name)] = {
+            key: value for key, value in server.items() if key != "disabled"
+        }
+    return active

--- a/src/mcp_manager.py
+++ b/src/mcp_manager.py
@@ -7,6 +7,7 @@ from langchain_mcp_adapters.client import MultiServerMCPClient
 from langchain_openai import ChatOpenAI
 from langgraph.prebuilt import create_react_agent
 from dotenv import load_dotenv
+from src.mcp_config import active_servers, configured_servers
 # from loguru import logger  # 已移除
 
 
@@ -120,7 +121,11 @@ class MCPManager:
                 await self.close()
             
             # 使用配置创建MCP客户端
-            config = mcp_config or self.config.get("servers", {})
+            if mcp_config is None:
+                servers = configured_servers(self.config)
+            else:
+                servers = mcp_config
+            config = active_servers(servers)
             if not config:
                 print("⚠️ 未找到MCP服务器配置，跳过MCP初始化")
                 return False

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+
+from src.mcp_config import active_servers, configured_servers
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_repository_configs_use_one_canonical_schema():
+    for filename in ("mcp_config.json", "mcp_config.json.example"):
+        config = json.loads((ROOT / filename).read_text(encoding="utf-8"))
+        assert "mcpServers" in config
+        assert "servers" not in config
+
+
+def test_fxmacrodata_is_opt_in_and_needs_no_repository_credential():
+    config = json.loads((ROOT / "mcp_config.json.example").read_text(encoding="utf-8"))
+    servers = configured_servers(config)
+
+    assert servers["fxmacrodata"] == {
+        "disabled": True,
+        "timeout": 600,
+        "transport": "streamable_http",
+        "url": "https://mcp.fxmacrodata.com",
+    }
+    assert "fxmacrodata" not in active_servers(servers)
+
+
+def test_active_servers_supports_legacy_key_and_strips_control_fields():
+    servers = configured_servers(
+        {
+            "servers": {
+                "enabled": {"disabled": False, "transport": "http", "url": "https://example.com"},
+                "disabled": {"disabled": True, "transport": "http", "url": "https://example.test"},
+            }
+        }
+    )
+
+    assert active_servers(servers) == {
+        "enabled": {"transport": "http", "url": "https://example.com"}
+    }


### PR DESCRIPTION
## Summary

This makes the FXMacroData MCP entry safe to opt into without changing TradingAgents' agent logic. The repository now has one canonical `mcpServers` configuration, while the loader still accepts the older `servers` key for existing user files.

FXMacroData is disabled by default. When enabled, the existing MCP client discovers the hosted server's tools at runtime; no API key or local copy of the tool schema is stored in this repository.

## Changes

- normalize the two MCP configuration shapes in one helper
- strip local `disabled` control fields before creating `MultiServerMCPClient`
- keep the hosted FXMacroData server opt-in
- document the no-key hosted endpoint
- add focused configuration tests

## Coverage

| FXMacroData capability | TradingAgents surface |
| --- | --- |
| Catalogue | Server-discovered MCP tools |
| Macro history | Server-discovered MCP tools |
| Release calendar | Server-discovered MCP tools |
| Predictions | Available only when advertised by the hosted server |
| Macro news | Server-discovered MCP tools |
| FX history | Server-discovered MCP tools |
| Market sessions | Server-discovered MCP tools |
| COT | Server-discovered MCP tools |
| Commodities | Server-discovered MCP tools |
| Seasonality | Available only when advertised by the hosted server |

## Validation

- `python -m pytest tests/test_mcp_config.py -q` — 3 passed
- both JSON configuration files parse successfully
- `git diff --check`
- credential, local/private-path, and automated-authorship scan: no findings

I own FXMacroData and am contributing this integration directly.
